### PR TITLE
CDNless (local) jQuery and highlight.js

### DIFF
--- a/reflow-maven-skin/src/main/resources/META-INF/maven/site.vm
+++ b/reflow-maven-skin/src/main/resources/META-INF/maven/site.vm
@@ -1375,8 +1375,14 @@
 		*##else#*
 			*##set ( $highlightJsTheme = 'default' )#*
 		*##end#*
-		// use a hosted version of highlight.js for syntax highlighting	*###
-		<link href="$protocol//yandex.st/highlightjs/7.3/styles/${highlightJsTheme}.min.css" rel="stylesheet" />
+		// use the local highlightJs path if set
+		*##if ( $config.is( "highlightJsLocal" ) )#*
+			*##set ( $highlightJsCssPath = "$resourcePath/css" )#*
+		*##else#*
+			*##set ( $highlightJsCssPath = "$protocol//yandex.st/highlightjs/7.3/styles" )#*
+		*##end#*
+		// use highlight.js for syntax highlighting	*###
+		<link href="$highlightJsCssPath/${highlightJsTheme}.min.css" rel="stylesheet" />
 #*	*##end##
 		
 #*	*##if ( !$config.not( "imgLightbox" ) )#*
@@ -1663,7 +1669,8 @@
 	<!-- Placed at the end of the document so the pages load faster -->
 
 #*	
-	*##set ( $jQueryVersion = "1.8.3" )##
+	*##set ( $jQueryVersion = "1.8.3" )#*
+		*##if ( $config.not( "localjQuery" ) )##
 	<!-- Fallback jQuery loading from Google CDN:
 	     http://stackoverflow.com/questions/1014203/best-way-to-use-googles-hosted-jquery-but-fall-back-to-my-hosted-library-on-go -->
 	<script type="text/javascript" src="$protocol//ajax.googleapis.com/ajax/libs/jquery/${jQueryVersion}/jquery.min.js"></script>
@@ -1673,7 +1680,11 @@
 			document.write(unescape("%3Cscript src='$resourcePath/js/jquery-${jQueryVersion}.min.js' type='text/javascript'%3E%3C/script%3E"));
 		}
 	</script>
+#*	*##else##
+	<script src="$resourcePath/js/jquery-${jQueryVersion}.min.js"></script>
+#*	*##end#*
 	
+*###
 	<script src="$bootstrapJsPath/bootstrap.min.js"></script>
 #*
 	*##if ( !$config.not( "imgLightbox" ) )#*
@@ -1689,8 +1700,14 @@
 #*	*##end#*
 
 	*##if ( $config.is( "highlightJs" ) )#*
-		// use a hosted version of highlight.js for syntax highlighting	*###
-	<script src="$protocol//yandex.st/highlightjs/7.3/highlight.min.js"></script>
+		// use the local highlightJs path if set
+		*##if ( $config.is( "highlightJsLocal" ) )#*
+			*##set ( $highlightJsScriptPath = "$resourcePath/js" )#*
+		*##else#*
+			*##set ( $highlightJsScriptPath = "$protocol//yandex.st/highlightjs/7.3" )#*
+		*##end#*
+		// use highlight.js for syntax highlighting	*###
+	<script src="$highlightJsScriptPath/highlight.min.js"></script>
 #*	*##end##
 
 	<script src="$resourcePath/js/reflow-skin.js"></script>

--- a/reflow-maven-skin/src/site/markdown/misc.md
+++ b/reflow-maven-skin/src/site/markdown/misc.md
@@ -28,9 +28,22 @@ element:
 -   **default (default)** - Default code highlighting theme is used
 -   **theme name** - Entered theme is used
 
+highlight.js is loaded from the [Yandex JS CDN][yandex-highlight-js-cdn].
+If you want to use a downloaded version, place the following files in `src/site/resources` and set the `<highlightJsLocal>` flag:
+
+-   `js/highlight.min.js`
+-   `css/THEME.css` (THEME is your chosen theme or `default` - see above)
+
+```xml
+<highlightJsLocal>true|false</highlightJsLocal>
+```
+
+-   **true** - Files from `src/site/resources` get used
+-   **false (default)** - [Yandex JS CDN][yandex-highlight-js-cdn] is used
+
 [highlight-js]: http://softwaremaniacs.org/soft/highlight/en/
 [highlight-js-themes]: http://softwaremaniacs.org/media/soft/highlight/test.html#styleswitcher
-
+[yandex-highlight-js-cdn]: http://api.yandex.ru/jslibs/libs.xml#highlightjs
 
 ### Image previews (lightbox)
 
@@ -177,6 +190,20 @@ For this reason, the protocol-relative URLs are disabled by default. Enable them
 
 [protocol-url]: http://paulirish.com/2010/the-protocol-relative-url/
 
+## Local jQuery
+
+By default, jQuery gets loaded from [Google Hosted Libraries CDN][google-js-cdn].
+If your site cannot use external CDNs, because it is intranet-only or for privacy reasons, set the
+`<localjQuery>` flag, so an already included jQuery version gets used:
+
+```xml
+<localjQuery>true|false</localjQuery>
+```
+
+-   **true** - included jQuery gets used
+-   **false (default)** - [Google Hosted Libraries][google-js-cdn] is used for jQuery
+
+[google-js-cdn]: https://developers.google.com/speed/libraries/
 
 ## Skin attribution
 


### PR DESCRIPTION
This PR introduces two new flags that can be used if you don't want to load jQuery and highlight.js from their CDNs, because the site is used in a completely offline environment.
