### PR TITLE
Maven Site Plugin 3.5+ compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>lt.velykis.maven.skins</groupId>
   <artifactId>reflow-parent</artifactId>
-  <version>1.1.2-SNAPSHOT</version>
+  <version>1.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Reflow Maven Skin Parent</name>
@@ -78,7 +78,7 @@
           <dependency>
             <groupId>lt.velykis.maven.skins</groupId>
             <artifactId>reflow-velocity-tools</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>${project.version}</version>
           </dependency>
           <dependency>
             <!-- Reflow skin requires velocity 1.7 -->
@@ -147,6 +147,11 @@
             <source>1.6</source>
             <target>1.6</target>
           </configuration>
+        </plugin>
+        <plugin>
+            <groupId>com.coderplus.maven.plugins</groupId>
+            <artifactId>copy-rename-maven-plugin</artifactId>
+            <version>1.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/reflow-maven-skin/pom.xml
+++ b/reflow-maven-skin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>lt.velykis.maven.skins</groupId>
     <artifactId>reflow-parent</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/reflow-maven-skin/src/main/resources/META-INF/maven/site.vm
+++ b/reflow-maven-skin/src/main/resources/META-INF/maven/site.vm
@@ -1466,7 +1466,7 @@
 
 
 #*	*##if ( $decoration.body.head )##
-		#htmlContent ( $decoration.body.head.getChildren() )
+#*	*#$render.eval( $decoration.body.head )
 #*	*##end#*
 
 	*##if( $headContent )#*
@@ -1739,7 +1739,7 @@
 
 
 	*##if ( $decoration.body.footer )##
-		#htmlContent ( $decoration.body.footer.getChildren() )
+		$render.eval( $decoration.body.footer )
 #*	*##end#*
 
 *###

--- a/reflow-velocity-tools/pom.xml
+++ b/reflow-velocity-tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>lt.velykis.maven.skins</groupId>
     <artifactId>reflow-parent</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -37,6 +37,29 @@
       <version>1.7.3</version>
     </dependency>
   </dependencies>
+  
+  <build>
+      <plugins>
+          <!-- https://issues.apache.org/jira/browse/DOXIASITETOOLS-168 tools.xml has to be at META-INF/maven/site-tools.xml -->
+          <plugin>
+              <groupId>com.coderplus.maven.plugins</groupId>
+              <artifactId>copy-rename-maven-plugin</artifactId>
+              <executions>
+                  <execution>
+                      <id>copy-tools-xml</id>
+                      <phase>process-resources</phase>
+                      <goals>
+                          <goal>copy</goal>
+                      </goals>
+                      <configuration>
+                          <sourceFile>src/main/resources/tools.xml</sourceFile>
+                          <destinationFile>${basedir}/target/classes/META-INF/maven/site-tools.xml</destinationFile>
+                      </configuration>
+                  </execution>
+              </executions>
+          </plugin>
+      </plugins>
+  </build>
 
   <reporting>
     <plugins>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -20,7 +20,7 @@
   <skin>
     <groupId>lt.velykis.maven.skins</groupId>
     <artifactId>reflow-maven-skin</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2-SNAPSHOT</version>
   </skin>
   <custom>
     <reflowSkin>


### PR DESCRIPTION
Allows the skin to be used when generating sites with maven-site-plugin
version 3.6 and higher.

- Add `copy-rename-maven-plugin` to create `META-INF/maven/site-tools.xml`
from `src/resources/tools.xml` see [DOXIASITETOOLS-168](https://issues.apache.org/jira/browse/DOXIASITETOOLS-168?focusedCommentId=15578066&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15578066).
- Changes `//body/head/*` and `//body/footer/*` rendering. See [Maven Site
Plugin migration from 3.4 to 3.5.1](https://maven.apache.org/plugins/maven-site-plugin/migrate.html#From_3.4_to_3.5.1)

Resolves andriusvelykis/reflow-maven-skin#49