### PR TITLE
Fix Versions Plugin Updates Report layout by disabling fixTableHeads

### DIFF
--- a/reflow-maven-skin/src/main/resources/META-INF/maven/site.vm
+++ b/reflow-maven-skin/src/main/resources/META-INF/maven/site.vm
@@ -1262,7 +1262,6 @@
 	*##if ( !$config.not( "bootstrapCss" ) )#*
 		// Bootstrap CSS class conversion is enabled by default, so check for false and negate
 		*##set ( $bodyContent = $htmlTool.addClass( $bodyContent, "table.bodyTable", ["table", "table-striped", "table-hover"] ) )#*
-		*##set ( $bodyContent = $htmlTool.fixTableHeads( $bodyContent ) )#*
 	*##end#*
 
 	*##if ( !$config.not( "bootstrapIcons" ) )#*


### PR DESCRIPTION
Fix Versions Plugin Updates Report layout by disabling HtmlTool.fixTableHeads.

Because it contains rows <tr>:

 - with only <th> at the top of the table for which <thead> is indeed correct.
 - with a combination of <th> and <td> which should stay in <tbody>.
 - with only <th> at the bottom of the table for which <tfoot> should be used.
