### PR TITLE
Switch to https protocol.

### DIFF
--- a/reflow-maven-skin/src/main/resources/META-INF/maven/site.vm
+++ b/reflow-maven-skin/src/main/resources/META-INF/maven/site.vm
@@ -1361,7 +1361,7 @@
 	*##if ( $config.is( "protocolRelativeURLs" ) )#*
 		*##set ( $protocol = "" )#*
 	*##else#*
-		*##set ( $protocol = "http:" )#*
+		*##set ( $protocol = "https:" )#*
 	*##end#*
 
 	// Use config option <absoluteResourceURL>http://mysite.com/</absoluteResourceURL>


### PR DESCRIPTION
Without this change for example http://andriusvelykis.github.io/reflow-maven-skin/ will not display correct when we switch to the ssl url https://andriusvelykis.github.io/reflow-maven-skin/

```
Blocked loading mixed active content “http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap.min.css”
https://andriusvelykis.github.io/reflow-maven-skin/
Line 0
```